### PR TITLE
fix wrong bracket typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ they are suitable for threading.
 ```clj
 (-> #js {}
     (j/assoc-in! [:x :y] 9)
-    (j/update-in! [:x :y) inc)
+    (j/update-in! [:x :y] inc)
     (j/get-in [:x :y]))
 
 #=> 10


### PR DESCRIPTION
not sure if this sort of drive-by fix is welcome, but if it is, here you go 😄 