### PR TITLE
feature(lit): nested literals, ie. recursive #js

### DIFF
--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -1,6 +1,7 @@
 (ns applied-science.js-interop
   (:refer-clojure :exclude [get get-in contains? select-keys assoc! unchecked-get unchecked-set apply extend])
   (:require [clojure.core :as core]
+            [clojure.walk :as walk]
             [clojure.string :as str]))
 
 (def ^:private reflect-property 'js/goog.reflect.objectProperty)
@@ -261,6 +262,22 @@
           `(-> ~empty-obj
                ~@(for [[k v] kvs]
                    `(assoc! ~k ~v))))))
+
+;; Literals
+
+(defmacro lit
+  "Returns literal JS forms for Clojure maps (->objects) and vectors (->arrays)."
+  [form]
+  (walk/prewalk
+   (fn [x]
+     (cond (map? x)
+           (list* 'applied-science.js-interop/obj
+                  (core/apply concat x))
+           (vector? x)
+           (list* 'cljs.core/array x)
+           :else x))
+   form))
+
 
 
 

--- a/src/test/applied_science/js_interop_test.cljs
+++ b/src/test/applied_science/js_interop_test.cljs
@@ -7,7 +7,8 @@
                                         deftest]]
             [clojure.pprint :refer [pprint]]
             [goog.object :as gobj]
-            [goog.reflect :as reflect]))
+            [goog.reflect :as reflect]
+            [clojure.walk :as walk]))
 
 (goog-define advanced? false)
 
@@ -601,4 +602,13 @@
 
     (is (clj= (j/extend! #js{:w 0} nil)
               {:w 0})
-        "extend with nil object")))
+        "extend with nil object"))
+
+  (testing "lit"
+
+    (is (object? (j/lit {})))
+    (is (array? (j/lit [])))
+    (is (object? (first (j/lit [{}]))))
+    (is (array? (-> (j/lit [{:a [{:b []}]}])
+                    (j/get-in [0 :a 0 :b]))))))
+


### PR DESCRIPTION
Proposal to add `j/lit` for nested js literals, like the `#js` reader tag, if it was recursive.

All maps/vectors are converted to objects/arrays, other values remain untouched. `j/obj` is used for object conversion, so all of js-interop's key formats would be supported.

Example:

```clj
(j/lit {:a [:b {:c :d}]})

;; =>
#js{:a #js[:b #js{:c :d}]}
```