### PR TITLE
Rewrite lit macro to not break on fns

### DIFF
--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -271,15 +271,15 @@
 
 ;; Nested literals (maps/vectors become objects/arrays)
 
+(defn- lit* [x]
+  (cond (map? x)
+        (list* 'applied-science.js-interop/obj
+               (core/apply concat   (reduce-kv #(assoc %1 %2 (lit-f %3)) {} x)))
+        (vector? x)
+        (list* 'cljs.core/array (into [] (map lit-f) x))
+        :else x))
+
 (defmacro lit
   "Returns literal JS forms for Clojure maps (->objects) and vectors (->arrays)."
   [form]
-  (walk/prewalk
-   (fn [x]
-     (cond (map? x)
-           (list* 'applied-science.js-interop/obj
-                  (core/apply concat x))
-           (vector? x)
-           (list* 'cljs.core/array x)
-           :else x))
-   form))
+  (lit* form))

--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -274,9 +274,9 @@
 (defn- lit* [x]
   (cond (map? x)
         (list* 'applied-science.js-interop/obj
-               (core/apply concat   (reduce-kv #(assoc %1 %2 (lit-f %3)) {} x)))
+               (reduce-kv #(conj %1 %2 (lit* %3)) [] x))
         (vector? x)
-        (list* 'cljs.core/array (into [] (map lit-f) x))
+        (list* 'cljs.core/array (mapv lit* x))
         :else x))
 
 (defmacro lit

--- a/src/test/applied_science/js_interop_test.cljs
+++ b/src/test/applied_science/js_interop_test.cljs
@@ -618,6 +618,7 @@
   (testing "lit"
 
     (is (object? (j/lit {})))
+    (is (object? (j/lit {:my-fn (fn [])})))
     (is (array? (j/lit [])))
     (is (object? (first (j/lit [{}]))))
     (is (array? (-> (j/lit [{:a [{:b []}]}])

--- a/src/test/applied_science/js_interop_test.cljs
+++ b/src/test/applied_science/js_interop_test.cljs
@@ -619,6 +619,7 @@
 
     (is (object? (j/lit {})))
     (is (object? (j/lit {:my-fn (fn [])})))
+    (is (fn? (j/get (j/lit {:my-fn (fn [])}) :my-fn)))
     (is (array? (j/lit [])))
     (is (object? (first (j/lit [{}]))))
     (is (array? (-> (j/lit [{:a [{:b []}]}])


### PR DESCRIPTION
I've rewritten the `lit` macro to not break on `fn` values, thanks for your implementation hint! Is this what you had in mind?

Closes #9.