### PR TITLE
Check for nil in `lookup` to make it useable in `when-let`

### DIFF
--- a/src/main/applied_science/js_interop.cljs
+++ b/src/main/applied_science/js_interop.cljs
@@ -90,7 +90,8 @@
    ...)
   ```"
   [obj]
-  (JSLookup. obj))
+  (when obj
+    (JSLookup. obj)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/src/test/applied_science/js_interop_test.cljs
+++ b/src/test/applied_science/js_interop_test.cljs
@@ -213,6 +213,10 @@
                                            :c 3}]))
     [1 2 3]
 
+    ;; lookup with nil
+    (j/lookup nil)
+    (apply j/lookup [nil])
+    nil
 
     ;; select-keys
     (j/select-keys #js {:x 10} [:x :y])


### PR DESCRIPTION
A minor change to make `lookup` return `nil` when given `nil` to make it useable in `when-let`.

Before:
```clojure
(defn my-fn [x]
  (when-let [{:keys [steps clientID]} (some-> x j/lookup)]
     ,,,))
```

After
```clojure
(defn my-fn [x]
  (when-let [{:keys [steps clientID]} (j/lookup x)]
     ,,,))
```