### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A JavaScript-interop library for ClojureScript.
   ...)
 
 ;; Destructure
-(j/let [^:js {:keys [a b c} o] ...)
+(j/let [^:js {:keys [a b c]} o] ...)
 (j/fn [^:js [n1 n2] ...)
 (j/defn my-fn [^:js {:syms [a b c]}])
 


### PR DESCRIPTION
This PR fixes a typo in the code example using `let`.

Cheers