### PR TITLE
no-op macros in clj?

### DIFF
--- a/src/main/applied_science/js_interop.cljc
+++ b/src/main/applied_science/js_interop.cljc
@@ -1,7 +1,7 @@
 (ns applied-science.js-interop
   (:refer-clojure :exclude [get get-in contains? select-keys assoc!
                             unchecked-get unchecked-set apply extend
-                            let fn defn array])
+                            let fn defn])
   (:require [clojure.core :as c]
             [cljs.compiler :as comp]
             [clojure.string :as str]

--- a/src/main/applied_science/js_interop/impl.cljs
+++ b/src/main/applied_science/js_interop/impl.cljs
@@ -1,5 +1,4 @@
-(ns applied-science.js-interop.impl
-  (:require-macros [applied-science.js-interop :as j]))
+(ns applied-science.js-interop.impl)
 
 (def lookup-sentinel #js{})
 
@@ -41,7 +40,7 @@
    (if-some [last-obj (get-value-by-keys obj (butlast ks*))]
      (let [k (peek ks*)]
        (if (js-in k last-obj)
-         (j/unchecked-get last-obj k)
+         (unchecked-get last-obj k)
          not-found))
      not-found)))
 
@@ -57,14 +56,14 @@
                                           (unchecked-get obj k))))) #js {})))
 (defn assoc-in*
   [obj ks* v]
-  (let [obj (j/some-or obj #js{})
+  (let [obj (if (some? obj) obj #js{})
         inner-obj (reduce get+! obj (butlast ks*))]
     (unchecked-set inner-obj (peek ks*) v)
     obj))
 
 (defn update-in*
   [obj ks* f args]
-  (let [obj (j/some-or obj #js{})
+  (let [obj (if (some? obj) obj #js{})
         last-k* (peek ks*)
         inner-obj (reduce get+! obj (butlast ks*))
         old-val (unchecked-get inner-obj last-k*)]

--- a/src/main/applied_science/js_interop/macros.cljc
+++ b/src/main/applied_science/js_interop/macros.cljc
@@ -1,0 +1,26 @@
+(ns applied-science.js-interop.macros)
+
+;; from macrovich/case https://github.com/cgrand/macrovich#usage
+(defmacro target [& {:keys [cljs clj]}]
+  (if (contains? &env '&env)
+    `(if (:ns ~'&env) ~cljs ~clj)
+    (if #?(:clj (:ns &env) :cljs true)
+      cljs
+      clj)))
+
+(defmacro defmacro-cljs
+  "defmacro with no-op in non-:cljs targets"
+  [name & args]
+  (let [[doc args] (if (string? (first args)) [(first args) (rest args)] [nil args])
+        [opts args] (if (map? (first args)) [(first args) (rest args)] [nil args])
+        kind (cond (list? (first args)) :multi-arity
+                   (vector? (first args)) :single-arity
+                   :else (throw (Exception. "Invalid defmacro form")))]
+    `(defmacro ~name ~@(keep identity [doc opts])
+       ~@(case kind
+           :single-arity
+           (let [[argv & body] args]
+             [argv (target :cljs `(do ~@body))])
+           :multi-arity
+           (for [[argv & body] args]
+             (list argv (target :cljs `(do ~@body))))))))

--- a/src/test/applied_science/js_interop_usage.cljc
+++ b/src/test/applied_science/js_interop_usage.cljc
@@ -23,103 +23,104 @@
         (log ~(str "------ " label " ------"))
         (log ~@body))))
 
+
+
+
+#?(:cljs (set! *warn-on-infer* true))
+
+(def ^:export o (j/obj))
+(def ^:export out (j/obj))
+(def ^:export o2 (j/obj .-world 10))
+
+(let [k (str "a" :b)]
+  (wrap "!get without hint - check inference"
+        (j/!get o k)))
+
+(wrap "!get without hint - inline expr"
+      (j/!get o (str "a" :b)))
+
+(wrap "!get with kw"
+      (let [k :some-key]
+        (j/!get o k)
+        ))
+
+(wrap "Array destructuring"
+      (j/let [a (j/lit [1 2 3 4 5])
+              ^:js [a b c & xs] a]
+        (j/lit [b xs])))
+
+
+(wrap "!get"
+      ((fn [o2]
+         (j/lit [(j/!get o2 .-world)
+                 #?(:cljs (.-world o2))]))
+       o2))
+
+#?(:cljs
+   (wrap "undefined"
+         (let [o (j/obj)]
+           (undefined? (j/!get o :whatever)))))
+
+(wrap "get-1"
+      (j/get o :something))
+
+(wrap "get-2"
+      (j/get o .-something))
+
+(wrap "get-3"
+      (j/get o :something "default"))
+
+(wrap "get-4"
+      (j/get o .-something "default"))
+
+(wrap "get-in-1"
+      (j/get-in o [:something :more]))
+
+(wrap "get-in-2"
+      (j/get-in o [.-something .-more]))
+
+(wrap "get-in-3"
+      (j/get-in o [:something :more] "default"))
+
+(wrap "get-in-4   3"
+      (j/get-in o [.-something .-more] "default"))
+
+(wrap "assoc-1"
+      (j/assoc! o :something "value"))
+
+(wrap "assoc-2"
+      (j/assoc! o .-something "value"))
+
+(wrap "assoc-in-1"
+      (j/assoc-in! o [:something :more] "value"))
+
+(wrap "assoc-in-2"
+      (j/assoc-in! o [.-something .-more] "value"))
+
+(wrap "update-1"
+      (j/update! o :something str "--suffix"))
+
+(wrap "update-2"
+      (j/update! o .-something str "--suffix"))
+
+(wrap "update-in-1"
+      (j/update-in! o [:something :more] str "--suffix"))
+
+(wrap "update-in-2"
+      (j/update-in! o [.-something .-more] str "value"))
+
+(wrap "select-keys-0 "
+      (j/select-keys o [:not-existing]))
+
+(wrap "select-keys-1"
+      (j/select-keys o [:something :more]))
+
+(wrap "select-keys-2"
+      (j/select-keys o [.-something]))
+
 #?(:cljs
    (do
-
-     (set! *warn-on-infer* true)
-
-     (def ^:export o #js{})
-     (def ^:export out #js{})
-     (def ^:export o2 (j/obj .-world 10))
-
-     (let [k (str "a" :b)]
-       (wrap "!get without hint - check inference"
-             (j/!get o k)))
-
-     (wrap "!get without hint - inline expr"
-           (j/!get o (str "a" :b)))
-
-     (wrap "!get with kw"
-           (let [k :some-key]
-             (j/!get o k)
-             ))
-
-     (wrap "Array destructuring"
-           (j/let [a #js[1 2 3 4 5]
-                   ^:js [a b c & xs] a]
-             (js/console.log #js[b xs])))
-
-     (wrap "!get"
-           ((fn [o2]
-              #js [(j/!get o2 .-world)
-                   (.-world o2)])
-            o2))
-
-     (wrap "undefined"
-           (let [o #js{}]
-             (undefined? (j/!get o :whatever))))
-
-     (wrap "get-1"
-           (j/get o :something))
-
-     (wrap "get-2"
-           (j/get o .-something))
-
-     (wrap "get-3"
-           (j/get o :something "default"))
-
-     (wrap "get-4"
-           (j/get o .-something "default"))
-
-     (wrap "get-in-1"
-           (j/get-in o [:something :more]))
-
-     (wrap "get-in-2"
-           (j/get-in o [.-something .-more]))
-
-     (wrap "get-in-3"
-           (j/get-in o [:something :more] "default"))
-
-     (wrap "get-in-4   3"
-           (j/get-in o [.-something .-more] "default"))
-
-     (wrap "assoc-1"
-           (j/assoc! o :something "value"))
-
-     (wrap "assoc-2"
-           (j/assoc! o .-something "value"))
-
-     (wrap "assoc-in-1"
-           (j/assoc-in! o [:something :more] "value"))
-
-     (wrap "assoc-in-2"
-           (j/assoc-in! o [.-something .-more] "value"))
-
-     (wrap "update-1"
-           (j/update! o :something str "--suffix"))
-
-     (wrap "update-2"
-           (j/update! o .-something str "--suffix"))
-
-     (wrap "update-in-1"
-           (j/update-in! o [:something :more] str "--suffix"))
-
-     (wrap "update-in-2"
-           (j/update-in! o [.-something .-more] str "value"))
-
-     (wrap "select-keys-0 "
-           (j/select-keys o [:not-existing]))
-
-     (wrap "select-keys-1"
-           (j/select-keys o [:something :more]))
-
-     (wrap "select-keys-2"
-           (j/select-keys o [.-something]))
-
-
      (goog-define debug false)
      ;; sanity-check: both of the following are DCE'd, the ^boolean hint is unnecessary
      (when debug (js/console.log "CCC"))
-     (when ^boolean debug (js/console.log "DDD"))
-
-     ))
+     (when ^boolean debug (js/console.log "DDD"))))


### PR DESCRIPTION
see #14 - desire to have these macros "not fail" in cljc files even when they are not in a `:cljs` conditional.

in this PR I experiment with modifying js-interop to "no-op" in clj. "it works on my machine" (I have the `js-interop.usage` namespace working in clj). I'm not sure if it should be merged.

thoughts on the problem in general:

- I don't see a general way to map js-interop to Clojure functions or macros. It's easy to think of cases where _particular_ mappings would be convenient, but no universal pattern. Sometimes `j/assoc!` would usefully map to `assoc`, sometimes to `assoc!`, and sometimes to `swap! x assoc ...`, all depending on how a particular cljs system was being re-expressed in clj. There are meaningful choices involved (how to express mutability, what to do about `.-host` keys, and so on) which can have different valid answers.
- In cases where a person wants to have a set of macros that truly target both cljs and clj, one could set up a namespace that uses something like [macrovich/case](https://github.com/cgrand/macrovich#usage) to differentially target clj/cljs at macroexpansion time. I've done this myself a couple times - one macro to create a data structure (an object for :cljs, an atom for :clj) and then a set of very simple get/assoc!/etc macros that delegate to the appropriate thing for each platform. Then you have a truly cross-platform API, with the constraints of your problem baked-in to the solution.
- So if anything is in the scope of this lib, I think it's the 'no-op' option, ie, "don't crash in a cljc file when run in Clojure". 

After implementing the no-op option, I remain skeptical. The "principle of least surprise" would lead me to expect that if I run cljs-only code in clj, it will crash. There might be chunks of cljs-only code where the surrounding forms do something in clj, and only the js-interop stuff is a no-op, and it happens silently, so could lead to difficult-to-debug situations.

@den1k I wonder if it would make more sense for your use-case, to have your UI layer elide lifecycle methods in clj? Eg if you have a macro for defining views:

```clj
(v/defview my-component 
  {:did-mount #(j/call! some/fn "hello")}
  [x] 
  [:div x])
```

.. the `defview` macro could ignore `:did-mount` & friends in `:clj` contexts.