### PR TITLE
add j/js (js-mode)

### DIFF
--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -548,6 +548,10 @@
   [& args]
   `(~'js/console.log ~@(map str-kw args)))
 
+(defmacro log-named
+  [& args]
+  `(log (j/obj ~@(mapcat (fn [a] [(keyword (str a)) a]) args))))
+
 (defmacro logret
   "like j/log but, returns the last argument"
   [& args]

--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -342,10 +342,7 @@
                                                    ;; renamable key
                                                    (comp/munge (dot-name k))
                                                    ;; static key
-                                                   (str \"
-                                                        ;; escape forward slashes (otherwise we generate invalid js)
-                                                        (str/escape (name k) {\\ "\\\\"})
-                                                        \"))
+                                                   (str \" (name k) \"))
                                                  ":~{}")) keyvals)
                                      (str/join ",")) "})")
           obj (vary-meta (list* 'js* keyvals-str (map second keyvals))
@@ -358,6 +355,7 @@
   [& keyvals]
   (c/let [kvs (partition 2 keyvals)]
     (if (every? #(or (keyword? %)
+                     (char? %)
                      (string? %)
                      (dot-sym? %)
                      (vector? %)) (map first kvs))

--- a/src/main/applied_science/js_interop.clj
+++ b/src/main/applied_science/js_interop.clj
@@ -270,6 +270,9 @@
       `(~'applied-science.js-interop.impl/update-in* ~obj ~(wrap-keys ks) ~f ~(vec args)))
     `(c/update-in ~obj ~ks ~f ~@args)))
 
+(defmacro delete! [obj k]
+  `(doto ~obj (~'js-delete ~(wrap-key &env obj k))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Array operations

--- a/src/main/applied_science/js_interop/destructure.cljc
+++ b/src/main/applied_science/js_interop/destructure.cljc
@@ -2,7 +2,8 @@
   (:refer-clojure :exclude [destructure])
   (:require [clojure.string :as str]
             [clojure.core :as c]
-            [clojure.spec.alpha :as s]))
+            [clojure.spec.alpha :as s]
+            [clojure.walk :as walk]))
 
 (defn- dequote [x]
   (if (and (list? x) (= 'quote (first x)))
@@ -17,6 +18,21 @@
 
 (def ^:dynamic *js?* false)
 
+(defn maybe-tag-js [sym]
+  (c/let [m (meta sym)]
+    (cond-> sym
+            (and (not (:clj m))
+                 (not (:tag m)))
+            (vary-meta assoc :tag 'js))))
+
+(defn js-tag-all [expr]
+  (walk/postwalk (c/fn [param]
+                   (cond-> param (symbol? param) maybe-tag-js))
+                 expr))
+
+(defn js-tag? [m] (or (:js m) (= 'js (:tag m))))
+(defn clj-tag? [m] (or (:clj m) (= 'clj (:tag m))))
+
 (c/defn destructure
   "Destructure with direct array and object access.
 
@@ -29,17 +45,15 @@
   [bindings]
   ;; modified from cljs.core/destructure
   (c/let [bents (partition 2 bindings)
+          js? (or *js?* (js-tag? (meta bindings)))
           pb (c/fn pb [bvec b v]
                (let [b-meta (meta b)
-                     js? (boolean (cond (:clj b-meta) false
-                                        (= 'clj (:tag b-meta)) false
-                                        *js?* true
-                                        :else (or (:js b-meta)
-                                                  (:js/shallow b-meta)
-                                                  (= 'js (:tag b-meta)))))]
-                 (binding [*js?* (if (:js/shallow b-meta)
-                                   false
-                                   js?)]
+                     _ (assert (not (:js/shallow b-meta)) "Deprecated :js/shallow meta, use ^clj instead")
+                     js? (boolean (cond (clj-tag? b-meta) false
+                                        (js-tag? b-meta) true
+                                        js? true
+                                        :else false))]
+                 (binding [*js?* js?]
                    (c/let [pvec
                            (c/fn [bvec b v]
                              (c/let [gvec (gensym "vec__")
@@ -55,8 +69,8 @@
                                      get-rest (fn [n]
                                                 (if js?
                                                   `(some->
-                                                     ~(with-meta gvec {:tag 'array})
-                                                     (.slice ~n))
+                                                    ~(with-meta gvec {:tag 'array})
+                                                    (.slice ~n))
                                                   gseq))]
                                (c/loop [ret (c/let [ret (cond-> (conj bvec gvec v)
                                                                 js? (conj gvec? `(some? ~gvec)))]
@@ -102,24 +116,24 @@
                                                        ret))))
                                         bes (c/let [transforms
                                                     (reduce
-                                                      (c/fn [transforms mk]
-                                                        (if (c/keyword? mk)
-                                                          (c/let [mkns (namespace mk)
-                                                                  mkn (name mk)]
-                                                            (c/cond (= mkn "keys") (assoc transforms mk #(keyword (c/or mkns (namespace %)) (name %)))
-                                                                    (= mkn "syms") (assoc transforms mk #(c/list `quote (symbol (c/or mkns (namespace %)) (name %))))
-                                                                    (= mkn "strs") (assoc transforms mk c/str)
-                                                                    :else transforms))
-                                                          transforms))
-                                                      {}
-                                                      (keys b))]
+                                                     (c/fn [transforms mk]
+                                                       (if (c/keyword? mk)
+                                                         (c/let [mkns (namespace mk)
+                                                                 mkn (name mk)]
+                                                           (c/cond (= mkn "keys") (assoc transforms mk #(keyword (c/or mkns (namespace %)) (name %)))
+                                                                   (= mkn "syms") (assoc transforms mk #(c/list `quote (symbol (c/or mkns (namespace %)) (name %))))
+                                                                   (= mkn "strs") (assoc transforms mk c/str)
+                                                                   :else transforms))
+                                                         transforms))
+                                                     {}
+                                                     (keys b))]
                                               (reduce
-                                                (c/fn [bes entry]
-                                                  (reduce #(assoc %1 %2 ((val entry) %2))
-                                                          (dissoc bes (key entry))
-                                                          ((key entry) bes)))
-                                                (dissoc b :as :or)
-                                                transforms))]
+                                               (c/fn [bes entry]
+                                                 (reduce #(assoc %1 %2 ((val entry) %2))
+                                                         (dissoc bes (key entry))
+                                                         ((key entry) bes)))
+                                               (dissoc b :as :or)
+                                               transforms))]
                                  (if (seq bes)
                                    (c/let [bb (key (first bes))
                                            bk (val (first bes))
@@ -142,10 +156,10 @@
                                                 (c/list getf gmap bk (defaults local))
                                                 (c/list getf gmap bk))]
                                      (recur
-                                       (if (c/or (c/keyword? bb) (c/symbol? bb)) ;(ident? bb)
-                                         (c/-> ret (conj local bv))
-                                         (pb ret bb bv))
-                                       (next bes)))
+                                      (if (c/or (c/keyword? bb) (c/symbol? bb)) ;(ident? bb)
+                                        (c/-> ret (conj local bv))
+                                        (pb ret bb bv))
+                                      (next bes)))
                                    ret))))]
                      (c/cond
                        (c/symbol? b) (c/-> bvec (conj (if (namespace b) (symbol (name b)) b)) (conj v))
@@ -153,16 +167,22 @@
                        (vector? b) (pvec bvec b v)
                        (map? b) (pmap bvec b v)
                        :else (throw
-                               #?(:clj  (new Exception (c/str "Unsupported binding form: " b))
-                                  :cljs (new js/Error (c/str "Unsupported binding form: " b)))))))))
+                              #?(:clj  (new Exception (c/str "Unsupported binding form: " b))
+                                 :cljs (new js/Error (c/str "Unsupported binding form: " b)))))))))
           process-entry (c/fn [bvec b] (pb bvec (first b) (second b)))]
-    (if (every? c/symbol? (map first bents))
-      bindings
-      (c/if-let [kwbs (seq (filter #(c/keyword? (first %)) bents))]
-        (throw
-          #?(:clj  (new Exception (c/str "Unsupported binding key: " (ffirst kwbs)))
-             :cljs (new js/Error (c/str "Unsupported binding key: " (ffirst kwbs)))))
-        (reduce process-entry [] bents)))))
+    (->> (if (every? c/symbol? (map first bents))
+           bindings
+           (c/if-let [kwbs (seq (filter #(c/keyword? (first %)) bents))]
+             (throw
+              #?(:clj  (new Exception (c/str "Unsupported binding key: " (ffirst kwbs)))
+                 :cljs (new js/Error (c/str "Unsupported binding key: " (ffirst kwbs)))))
+             (reduce process-entry [] bents)))
+         (partition 2)
+         (mapcat (if js?
+                   (fn [[k v]]
+                     [(maybe-tag-js k) v])
+                   identity))
+         vec)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -170,9 +190,9 @@
 
 (s/def ::argv+body
   (s/cat :params (s/and
-                   vector?
-                   (s/conformer identity vec)
-                   (s/cat :params (s/* any?)))
+                  vector?
+                  (s/conformer identity vec)
+                  (s/cat :params (s/* any?)))
          :body (s/alt :prepost+body (s/cat :prepost map?
                                            :body (s/+ any?))
                       :body (s/* any?))))
@@ -217,7 +237,7 @@
                    (conj lets (first params) gparam))))
         [new-params
          `[(~'applied-science.js-interop/let ~lets
-             ~@body)]]))))
+            ~@body)]]))))
 
 (c/defn destructure-fn-args [args]
   (spec-reform ::function-args args #(update-argv+body maybe-destructured %)))

--- a/src/main/applied_science/js_interop/destructure.cljc
+++ b/src/main/applied_science/js_interop/destructure.cljc
@@ -109,7 +109,7 @@
                                (c/let [gmap (gensym "map__")
                                        defaults (:or b)]
                                  (c/loop [ret (c/-> bvec (conj gmap) (conj v)
-                                                    (conj gmap) (conj `(if (~'cljs.core/implements? c/ISeq ~gmap) (apply cljs.core/hash-map ~gmap) ~gmap))
+                                                    (conj gmap) (conj `(if (seq? ~gmap) (apply cljs.core/hash-map ~gmap) ~gmap))
                                                     ((c/fn [ret]
                                                        (if (:as b)
                                                          (conj ret (:as b) gmap)


### PR DESCRIPTION
Status: experimental.

`j/js` is a kind of js-mode which combines a deep `j/lit` (does not stop at lists) with js-destructuring as default for all `let/fn/defn` forms. Quite inspired by @borkdude's recent experiments with alternative cljs transpilers.

Other than binding vectors and fn metadata, all data structures will be js by default (arrays/objects) and all destructuring forms perform `j/get` for reads. Further, all bound variables are tagged as `js` so that further reads in fn/let bodies don't need additional `^js` hinting.

One can escape all this at any time with `^clj` or `^:clj` metadata on a form.

I am finding this useful for interop-heavy situations (eg. writing ProseMirror/CodeMirror integration code) where I'm actually not using any clj structures at all.